### PR TITLE
log refine

### DIFF
--- a/src/recorders/recorder.go
+++ b/src/recorders/recorder.go
@@ -253,7 +253,9 @@ func (r *recorder) setAndCloseParser(p parser.Parser) {
 	r.parserLock.Lock()
 	defer r.parserLock.Unlock()
 	if r.parser != nil {
-		r.parser.Stop()
+		if err := r.parser.Stop(); err != nil {
+			r.getLogger().WithError(err).Warn("failed to end recorder")
+		}
 	}
 	r.parser = p
 }
@@ -279,7 +281,9 @@ func (r *recorder) Close() {
 	}
 	close(r.stop)
 	if p := r.getParser(); p != nil {
-		p.Stop()
+		if err := p.Stop(); err != nil {
+			r.getLogger().WithError(err).Warn("failed to end recorder")
+		}
 	}
 	r.getLogger().Info("Record End")
 	r.ed.DispatchEvent(events.NewEvent(RecorderStop, r.Live))


### PR DESCRIPTION
这个 [PR](https://github.com/hr3lxphr6j/bililive-go/pull/675) 原本的 log 相关部分报[编译错误](https://github.com/hr3lxphr6j/bililive-go/actions/runs/7780991299/job/21273859490?pr=675)了。我加了一些代码支持把错误信息抛出去，另外稍微细化了一下错误信息。