### PR TITLE
修复--rsp是ReadableStream，只能读一次。如果 rsp.json() 失败后再去 rsp.text() 会失败。所以原始代…

### DIFF
--- a/src/webapp/src/utils/common.ts
+++ b/src/webapp/src/utils/common.ts
@@ -12,13 +12,14 @@ function customFetch(arg1: Parameters<typeof fetch>[0], ...args: any[]) {
                     return rsp.json();
                 } else {
                     // Try to parse error message from JSON or text
+                    const clonedRsp = rsp.clone();
                     let errMsg = '';
                     try {
                         const data = await rsp.json();
                         errMsg = data.err_msg || data.message || rsp.statusText;
                     } catch (e) {
                         try {
-                            errMsg = await rsp.text() || rsp.statusText;
+                            errMsg = await clonedRsp.text() || rsp.statusText;
                         } catch (e2) {
                             errMsg = rsp.statusText;
                         }


### PR DESCRIPTION
…码 clone 了一个 response 使用。